### PR TITLE
Fixes for jQuery IE XHR error and test for existing subject and from to prevent Zend Mail Error

### DIFF
--- a/app/code/local/Sailthru/Email/Model/Email/Template.php
+++ b/app/code/local/Sailthru/Email/Model/Email/Template.php
@@ -2,13 +2,13 @@
 /**
  * This class overwrites Magento's default send functionality by routing all
  * emails through Sailthru using the Send API call.  Documentation can be found
- * online at http://getstarted.sailthru.com/api/send.  
- * 
+ * online at http://getstarted.sailthru.com/api/send.
+ *
  * @category  Sailthru
  * @package   Sailthru_Email
  * @author    Kwadwo Juantuah <support@sailthru.com>
  */
-class Sailthru_Email_Model_Email_Template extends Mage_Core_Model_Email_Template {   
+class Sailthru_Email_Model_Email_Template extends Mage_Core_Model_Email_Template {
     /**
      * Send mail to recipient
      *
@@ -17,7 +17,7 @@ class Sailthru_Email_Model_Email_Template extends Mage_Core_Model_Email_Template
      * @param   array              $variables    template variables
      * @return  boolean
      **/
-    public function send($email, $name = null, array $variables = array()) 
+    public function send($email, $name = null, array $variables = array())
     {
         //Return default parent method if Sailthru Extension or Transactional Email has not been enabled
         if(!Mage::helper('sailthruemail')->isEnabled() || !Mage::helper('sailthruemail')->isTransactionalEmailEnabled()){
@@ -69,8 +69,8 @@ class Sailthru_Email_Model_Email_Template extends Mage_Core_Model_Email_Template
         } else {
             $mail->setBodyHTML($text);
         }
-        $mail->setSubject('=?utf-8?B?' . base64_encode($this->getProcessedTemplateSubject($variables)) . '?=');
-        $mail->setFrom($this->getSenderEmail(), $this->getSenderName());
+        if (!$mail->getSubject()) $mail->setSubject('=?utf-8?B?' . base64_encode($this->getProcessedTemplateSubject($variables)) . '?=');
+        if (!$mail->getFrom()) $mail->setFrom($this->getSenderEmail(), $this->getSenderName());
 
         //sailthru//
         try {
@@ -105,7 +105,7 @@ class Sailthru_Email_Model_Email_Template extends Mage_Core_Model_Email_Template
         }
 
         return true;
-    } 
+    }
 
 }
 ?>

--- a/app/code/local/Sailthru/Email/Model/Observer.php
+++ b/app/code/local/Sailthru/Email/Model/Observer.php
@@ -385,7 +385,7 @@ class Sailthru_Email_Model_Observer
                                       'isVirtual'  => $product->isVirtual(),
                                       'isRecurring' => $product->isRecurring(),
                                       'isInStock'  => $product->isInStock(),
-                                      'weight'  => $product->getSku(),
+                                      'weight'  => $product->getWeight(),
                                       'imageUrl'  => $product->getImageUrl(),        //deprecated so may change
                                       'smallImageUrl' => $product->getSmallImageUrl($width = 88, $height = 77),  //Using Magento default setting - deprecated
                                       'thumbnailUrl' => $product->getThumbnailUrl($width = 75, $height = 75),        //Using Magento default settings - deprecated

--- a/app/code/local/Sailthru/Email/Model/Observer.php
+++ b/app/code/local/Sailthru/Email/Model/Observer.php
@@ -340,6 +340,15 @@ class Sailthru_Email_Model_Observer
 
     public function getProductData($product)
     {
+        // If product is not a configurable, let's see if it has parent ids, and use that for images,etc
+        if($product->getProductType() != 'configurable')
+        {
+            $parentIdArray = Mage::getResourceSingleton('catalog/product_type_configurable')->getParentIdsByChild($product->getId());
+            Mage::log("parents:".$parentIdArray);
+            if(!empty($parentIdArray)) {
+               $product = Mage::getModel('catalog/product')->load($parentIdArray[0]);
+            }
+        }
 
         $data = array('url' => $product->getProductUrl(),
                       'title' => htmlspecialchars($product->getName()),

--- a/app/design/frontend/base/default/layout/sailthru.xml
+++ b/app/design/frontend/base/default/layout/sailthru.xml
@@ -5,15 +5,15 @@
 Default layout, loads most of the pages
 -->
         <catalog_product_view>
-        <reference name="head"> 
+        <reference name="head">
             <block type="core/text" name="google.cdn.jquery">
                 <action method="setText">
-                    <text><![CDATA[<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.8.0/jquery.min.js"></script><script type="text/javascript">jQuery.noConflict();</script>]]>
+                    <text><![CDATA[<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js"></script><script type="text/javascript">jQuery.noConflict();</script>]]>
                     </text>
                 </action>
             </block>
             <block type="catalog/product_view" name="sailthru_horizon" as="sailthru_horizon" template="sailthru/horizon.phtml" />
        </reference>
        </catalog_product_view>
-    
+
 </layout>


### PR DESCRIPTION
a) 
1.8.0 jQuery causes IE error on our product detail pages and prevents other scripts from running (thus preventing add to cart). 1.8.2 fixes XHR error.

b) 
if (!$mail->getSubject()) check before setting subject
if (!$mail->getFrom())  check before setting From
Zend Mail was failing preventing some system transactional emails from sending.
