### PR TITLE
Prevent Zend_Mail exceptions

### DIFF
--- a/app/code/local/Sailthru/Email/Model/Email/Template.php
+++ b/app/code/local/Sailthru/Email/Model/Email/Template.php
@@ -69,8 +69,17 @@ class Sailthru_Email_Model_Email_Template extends Mage_Core_Model_Email_Template
         } else {
             $mail->setBodyHTML($text);
         }
-        $mail->setSubject('=?utf-8?B?' . base64_encode($this->getProcessedTemplateSubject($variables)) . '?=');
-        $mail->setFrom($this->getSenderEmail(), $this->getSenderName());
+
+        //Prevent Zend_Mail "Subject Set Twice" Error
+        $mail_subject = '=?utf-8?B?' . base64_encode($this->getProcessedTemplateSubject($variables)) . '?=';
+        $mail->clearSubject();
+        $mail->setSubject($mail_subject);
+
+        //Prevent Zend_Mail "From Set Twice" Error
+        $mail_from_email = $this->getSenderEmail();
+        $mail_from_name = $this->getSenderName();
+        $mail->clearFrom();
+        $mail->setFrom($mail_from_email, $mail_from_name);
 
         //sailthru//
         try {


### PR DESCRIPTION
Zend_Mail throws exceptions when Subject or From field is set twice
without calling clearSubject() or clearFrom(). This patch fixes that.
