### PR TITLE
Use Configurable URLs for Simple Products

### DIFF
--- a/app/code/local/Sailthru/Email/Model/Observer.php
+++ b/app/code/local/Sailthru/Email/Model/Observer.php
@@ -269,7 +269,8 @@ class Sailthru_Email_Model_Observer
                                       'isVirtual'  => $product->isVirtual(),
                                       'id' => $product->getSku(),
                 ),"PRODUCT");
-                
+
+
                 //Use Configurable Product URL for Simple Products 
                 $parentID = Mage::getModel('catalog/product_type_configurable')->getParentIdsByChild( $product->getId() ); 
                 if (isset($parentID[0])){


### PR DESCRIPTION
If a user purchases a configurable item, the URL passed via the Purchase API will be specific to the options of that item. These URLs do not work and cause broken links in the content collection.

For instance, if I buy a size 10 pair of shoes, the URL will be the following (this 404s):
http://www.sailthru-support.com/magento/index.php/asics-men-s-gel-kayano-xii-10.html

This adds a check for simple (child) items and replaces the url with the configurable (parent) url, e.g.:
http://www.sailthru-support.com/magento/index.php/asics-men-s-gel-kayano-xii.html
