### PR TITLE
Fix API Data Structure for Purchases with Adjustments

### DIFF
--- a/app/code/local/Sailthru/Email/Model/Client/Purchase.php
+++ b/app/code/local/Sailthru/Email/Model/Client/Purchase.php
@@ -186,9 +186,11 @@ class Sailthru_Email_Model_Client_Purchase extends Sailthru_Email_Model_Client
     {
         if ($order->getBaseDiscountAmount()) {
             return array(
-                   'title' => 'Sale',
-                   'price' => Mage::helper('sailthruemail')->formatAmount($order->getBaseDiscountAmount())
-                   );
+                array(
+                    'title' => 'Sale',
+                    'price' => Mage::helper('sailthruemail')->formatAmount($order->getBaseDiscountAmount())
+                )
+            );
         }
 
         return array();


### PR DESCRIPTION
Adjustments need to be passed as an array, not a single key-value hash.