### PR TITLE
Loading Horizon with useStoredTags, and loading JS on every page

### DIFF
--- a/app/code/community/Sailthru/Email/Block/Js.php
+++ b/app/code/community/Sailthru/Email/Block/Js.php
@@ -8,11 +8,12 @@
  */
 
 
-class Sailthru_Email_Block_Js extends Mage_Page_Block_Html_Head
+class Sailthru_Email_Block_Js extends Mage_Page_Block_Html
 {
     protected function _construct() {
         $sailthruHelper = Mage::helper('sailthruemail');
         if ($sailthruHelper->isPersonalizeJsEnabled() and $sailthruHelper->getCustomerId()) {
+            Mage::log("SPM time!", null, "sailthru.log");
             $this->setTemplate("sailthru/spm.phtml");
         } elseif ($sailthruHelper->isHorizonEnabled() and $sailthruHelper->getHorizonDomain()) {
             $this->setTemplate("sailthru/horizon.phtml");

--- a/app/design/frontend/base/default/layout/sailthru.xml
+++ b/app/design/frontend/base/default/layout/sailthru.xml
@@ -1,15 +1,9 @@
 <?xml version="1.0"?>
 
 <layout version="0.1.0">
-    <catalog_product_view>
-        <reference name="head"> 
-            <block type="core/text" name="google.cdn.jquery">
-                <action method="setText">
-                    <text><![CDATA[<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.8.0/jquery.min.js"></script><script type="text/javascript">jQuery.noConflict();</script>]]>
-                    </text>
-                </action>
-            </block>
+    <default>
+        <reference name="head">
             <block type="Sailthru_Email_Block_Js" name="sailthru_js" />
        </reference>
-   </catalog_product_view>
+   </default>
 </layout>

--- a/app/design/frontend/base/default/template/sailthru/horizon.phtml
+++ b/app/design/frontend/base/default/template/sailthru/horizon.phtml
@@ -7,28 +7,29 @@
  */
 ?>
 <!--BEGIN SAILTHRU HORIZON -->
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.8.0/jquery.min.js"></script>
 <script type="text/javascript">
-<![CDATA[
-    (function() {
-        function loadHorizon() {
-            var s = document.createElement('script');
-            s.type = 'text/javascript';
-            s.async = true;
-            s.src = location.protocol + '//ak.sail-horizon.com/horizon/v1.js';
-            var x = document.getElementsByTagName('script')[0];
-            x.parentNode.insertBefore(s, x);
+jQuery.noConflict();
+(function() {
+    function loadHorizon() {
+        var s = document.createElement('script');
+        s.type = 'text/javascript';
+        s.async = true;
+        s.src = location.protocol + '//ak.sail-horizon.com/horizon/v1.js';
+        var x = document.getElementsByTagName('script')[0];
+        x.parentNode.insertBefore(s, x);
+    }
+    loadHorizon();
+    var oldOnLoad = window.onload;
+    window.onload = function() {
+        if (typeof oldOnLoad === 'function') {
+            oldOnLoad();
         }
-        loadHorizon();
-        var oldOnLoad = window.onload;
-        window.onload = function() {
-            if (typeof oldOnLoad === 'function') {
-                oldOnLoad();
-            }
-            Sailthru.setup({
-                domain: '<?php echo Mage::helper('sailthruemail')->getHorizonDomain(); ?>'
-            });
-        };
-    })();
-]]>
+        Sailthru.setup({
+            domain: '<?php echo Mage::helper('sailthruemail')->getHorizonDomain(); ?>',
+            useStoredTags: true
+        });
+    };
+})();
 </script>
 <!-- END SAILTHRU HORIZON -->


### PR DESCRIPTION
Whether using PersonalizeJS or Horizon, Sailthru Javascript will load on all pages. Also, as we're removing meta-tags, we're turned on useStoredTags for Horizon by default.