### PR TITLE
Fix Register on Checkout + Tuneups

### DIFF
--- a/app/code/community/Sailthru/Email/Helper/Purchase.php
+++ b/app/code/community/Sailthru/Email/Helper/Purchase.php
@@ -106,6 +106,10 @@ class Sailthru_Email_Helper_Purchase extends Mage_Core_Helper_Abstract {
      */
     public function getVars($options)
     {
+        if (!$options) {
+            return null;
+        }
+
         $vars = array();
 
         if (array_key_exists('attributes_info', $options)) {

--- a/app/code/community/Sailthru/Email/Model/Client/Purchase.php
+++ b/app/code/community/Sailthru/Email/Model/Client/Purchase.php
@@ -71,10 +71,11 @@ class Sailthru_Email_Model_Client_Purchase extends Sailthru_Email_Model_Client
      */ 
     public function sendOrder(Mage_Sales_Model_Order $order)
     {
+        $this->log("\n\nOrder Fired!\n\n");
         $this->_eventType = 'Place Order';
         $data = [
             'email' => $order->getCustomerEmail(),
-            'items' => Mage::helper('sailthruemail/purchase')->getItems($order->getAllVisibleItems()),
+            'items' => $this->getItems($order->getAllVisibleItems()),
             'adjustments' => Mage::helper('sailthruemail/purchase')->getAdjustments($order, "api"),
             'message_id' => $this->getMessageId(),
             'tenders' => Mage::helper('sailthruemail/purchase')->getTenders($order),
@@ -94,6 +95,7 @@ class Sailthru_Email_Model_Client_Purchase extends Sailthru_Email_Model_Client
      */
     public function getItems($items)
     {
+        $this->log("GET ITEMS");
         try {
             $data = array();
             $configurableSkus = array();

--- a/app/code/community/Sailthru/Email/Model/Client/Purchase.php
+++ b/app/code/community/Sailthru/Email/Model/Client/Purchase.php
@@ -47,7 +47,7 @@ class Sailthru_Email_Model_Client_Purchase extends Sailthru_Email_Model_Client
 
             $data = array(
                     'email' => $email,
-                    'items' => Mage::helper('sailthruemail/purchase')->getItems($items),
+                    'items' => $this->getItems($items),
                     'incomplete' => 1,
                     'reminder_time' => '+' . $cartTime,
                     'reminder_template' => $cartTemplate,
@@ -71,8 +71,11 @@ class Sailthru_Email_Model_Client_Purchase extends Sailthru_Email_Model_Client
      */ 
     public function sendOrder(Mage_Sales_Model_Order $order)
     {
-        $this->log("\n\nOrder Fired!\n\n");
-        $this->_eventType = 'Place Order';
+        $quote = Mage::getModel('sales/quote')->load($order->getQuoteId());
+        $method = $quote->getCheckoutMethod(true);
+        if ($method == 'register'){
+            Mage::getModel('sailthruemail/client_user')->postNewCustomer($order->getCustomer());
+        }
         $data = [
             'email' => $order->getCustomerEmail(),
             'items' => $this->getItems($order->getAllVisibleItems()),

--- a/app/code/community/Sailthru/Email/Model/Client/User.php
+++ b/app/code/community/Sailthru/Email/Model/Client/User.php
@@ -40,6 +40,9 @@ class Sailthru_Email_Model_Client_User extends Sailthru_Email_Model_Client
         try {
             $data = $this->_buildCustomerPayload($customer, "update");
             $response = $this->apiPost('user', $data);
+            if (!$customer->getData('sailthru_id')) {
+                $this->_setSid($customer, $response);
+            }
         } catch (Exception $e) {
             $this->log($e);
         }
@@ -161,19 +164,19 @@ class Sailthru_Email_Model_Client_User extends Sailthru_Email_Model_Client
                 'prefix' => $customer->getPrefix() ? $customer->getPrefix() : '',
                 'firstName' => $customer->getFirstname(),
                 'middleName' => $customer->getMiddlename() ? $customer->getMiddlename() : '',
-                'fullName' => $customer->getFullName(),
                 'lastName' => $customer->getLastname(),
                 'website' => Mage::app()->getStore()->getWebsite()->getName(),
                 'store' => Mage::app()->getStore()->getName(),
                 'customerGroup' => Mage::getModel('customer/group')->load($customer->getGroupId())->getCustomerGroupCode(),
-                'createdAt' => date("Y-m-d H:i:s", $customer->getCreatedAtTimestamp()),
+                'created_date' => date("Y-m-d", $customer->getCreatedAtTimestamp()),
+                'created_time' => $customer->getCreatedAtTimestamp(),
             );
 
             if ($primaryBillingAddress = $customer->getPrimaryBillingAddress()){
-                $vars = $vars + $this->_getAddressVars($primaryBillingAddress, "billing_");
+                $vars["billingAddress"] = $this->_getAddressVars($primaryBillingAddress);
             }
             if ($primaryShippingAddress = $customer->getPrimaryShippingAddress()){
-                $vars = $vars + $this->_getAddressVars($primaryShippingAddress, "shipping_");
+                $vars["shippingAddress"] = $this->_getAddressVars($primaryShippingAddress);
             }
 
             return $vars;

--- a/app/code/community/Sailthru/Email/Model/Observer/User.php
+++ b/app/code/community/Sailthru/Email/Model/Observer/User.php
@@ -40,9 +40,9 @@ class Sailthru_Email_Model_Observer_User extends Sailthru_Email_Model_Abstract {
 
     /**
      * Capture customer updates
-     * @param Varian_Event_Observer $observer
+     * @param Varien_Event_Observer $observer
      */
-    public function update(Varian_Event_Observer $observer)
+    public function update(Varien_Event_Observer $observer)
     {
         $customer = $observer->getEvent()->getCustomer();
 

--- a/app/code/community/Sailthru/Email/etc/config.xml
+++ b/app/code/community/Sailthru/Email/etc/config.xml
@@ -79,15 +79,6 @@
                     </sailthru_customer_save>
                 </observers>
             </customer_save_before>
-            <customer_logout>
-                <observers>
-                    <sailthru_customer_logout>
-                        <type>singleton</type>
-                        <model>sailthruemail/observer_user</model>
-                        <method>logout</method>
-                    </sailthru_customer_logout>
-                </observers>
-            </customer_logout>
             <checkout_cart_update_items_after>
                 <observers>
                     <sailthru_checkout_cart_update_items_after>


### PR DESCRIPTION
Registration events aren't fired during registration on checkout. This uses the quote to check whether it's also a registration, and fires the Sailthru user registration functionality.

Various other tweaks as well.