### PR TITLE
Add Bulk Content API Product Action [WIP]

### DIFF
--- a/app/code/community/Sailthru/Email/Model/Client/Content.php
+++ b/app/code/community/Sailthru/Email/Model/Client/Content.php
@@ -115,7 +115,7 @@ class Sailthru_Email_Model_Client_Content extends Sailthru_Email_Model_Client
             )
         );
 
-        if ($isSimple) $data['inventory'] = $product->getStockItem()->getQty();
+        if ($isSimple) $data['inventory'] = $product->getStockItem()->getStockQty();
 
         // PRICE-FIXING CODE
         $data['price'] = Mage::helper('sailthruemail')->getPrice($product);

--- a/app/code/community/Sailthru/Email/Model/Observer/Adminhtml.php
+++ b/app/code/community/Sailthru/Email/Model/Observer/Adminhtml.php
@@ -1,0 +1,39 @@
+<?php
+
+class Sailthru_Email_Model_Observer_Adminhtml
+{
+    /**
+     * Catch loading of Catalog Product Admin and insert a new mass action to send to Sailthru.
+     * @param Varien_Event_Observer $observer
+     */
+    public function addBlockMassAction(Varien_Event_Observer $observer) {
+        /** @var Mage_Core_Block_Template $block */
+        $block = $observer->getEvent()->getBlock();
+        if(get_class($block) =='Mage_Adminhtml_Block_Widget_Grid_Massaction'
+            && $block->getRequest()->getControllerName() == 'catalog_product')
+        {
+            $massAction = [
+                'label' => 'Send to Sailthru Content Library',
+                'url' => Mage::app()->getStore()->getUrl('sailthruemail/content/bulk')
+            ];
+
+            /** @var Mage_Core_Model_Store[] $stores */
+            $stores = Mage::app()->getStores();
+            foreach ($stores as $store) {
+                Mage::log($store->debug(), null, "sailthru.log");
+            }
+            if (count($stores) > 1) {
+                $massAction['additional'] = [
+                    'store' => [
+                        'name' => 'store',
+                        'type' => 'select',
+                        'class' => 'required-entry',
+                        'label' => Mage::helper('catalog')->__('Store'),
+                        'values' => Mage::getResourceModel('core/store_collection')->load()->toOptionArray()
+                    ]
+                ];
+            }
+            $block->addItem('sailthruemail', $massAction);
+        }
+    }
+}

--- a/app/code/community/Sailthru/Email/Model/Observer/Content.php
+++ b/app/code/community/Sailthru/Email/Model/Observer/Content.php
@@ -74,6 +74,26 @@ class Sailthru_Email_Model_Observer_Content
         }
     }
 
+    /**
+     * Catch loading of Catalog Product Admin and insert a new mass action to send to Sailthru.
+     * @param Varien_Event_Observer $observer
+     */
+    public function addBlockMassAction(Varien_Event_Observer $observer) {
+        /** @var Mage_Core_Block_Template $block */
+        $block = $observer->getEvent()->getBlock();
+        if(get_class($block) =='Mage_Adminhtml_Block_Widget_Grid_Massaction'
+            && $block->getRequest()->getControllerName() == 'catalog_product')
+        {
+            Mage::log([
+                "class" => get_class($block),
+                "controller" => $block->getRequest()->getControllerName()
+            ], null, "sailthru.log");
+            $block->addItem('sailthruemail', array(
+                'label' => 'Send to Sailthru Content Library',
+                'url' => Mage::app()->getStore()->getUrl('sailthruemail/content/bulk'),
+            ));
+        }
+    }
     private function getScopedStores(Mage_Catalog_Model_Product $product)
     {
         $storeId = Mage::app()->getRequest()->getParam('store');

--- a/app/code/community/Sailthru/Email/Model/Observer/Content.php
+++ b/app/code/community/Sailthru/Email/Model/Observer/Content.php
@@ -80,22 +80,6 @@ class Sailthru_Email_Model_Observer_Content
         return $returnBool ? (count($savedStores) == count($stores)) : $savedStores;
     }
 
-    /**
-     * Catch loading of Catalog Product Admin and insert a new mass action to send to Sailthru.
-     * @param Varien_Event_Observer $observer
-     */
-    public function addBlockMassAction(Varien_Event_Observer $observer) {
-        /** @var Mage_Core_Block_Template $block */
-        $block = $observer->getEvent()->getBlock();
-        if(get_class($block) =='Mage_Adminhtml_Block_Widget_Grid_Massaction'
-            && $block->getRequest()->getControllerName() == 'catalog_product')
-        {
-            $block->addItem('sailthruemail', array(
-                'label' => 'Send to Sailthru Content Library',
-                'url' => Mage::app()->getStore()->getUrl('sailthruemail/content/bulk'),
-            ));
-        }
-    }
     private function getScopedStores(Mage_Catalog_Model_Product $product)
     {
         $storeId = Mage::app()->getRequest()->getParam('store');

--- a/app/code/community/Sailthru/Email/controllers/ContentController.php
+++ b/app/code/community/Sailthru/Email/controllers/ContentController.php
@@ -2,7 +2,33 @@
 class Sailthru_Email_ContentController extends Mage_Adminhtml_Controller_Action {
 
     public function bulkAction() {
+        $startTime = microtime(true);
         $data = $this->getRequest()->getPost();
-        Mage::log($data, null, "sailthru.log");
+
+        if ($data and array_key_exists('product', $data) and array_key_exists('massaction_prepare_key', $data)
+            and $pCount = count($data['product']) and $data['massaction_prepare_key'] == 'product') {
+
+            $savedProducts = 0;
+
+            /** @var int[] $productIds */
+            $productIds = $data['product'];
+            foreach ($productIds as $productId) {
+                /** @var Mage_Catalog_Model_Product $product */
+                $product = Mage::getModel('catalog/product')->load($productId);
+                $success = Mage::getModel('sailthruemail/observer_content')->syncProduct($product, true);
+                if ($success) ++$savedProducts;
+                usleep(0.25 * 1000000);
+            }
+
+            $endTime = microtime(true);
+            $time = $endTime - $startTime;
+            $message = "Succesfully sync'd $savedProducts / $pCount products to Sailthru";
+            Mage::getSingleton('adminhtml/session')->addNotice($message.".");
+            Mage::log($message . "in $time seconds", null, "sailthru.log");
+        } else {
+            unset($data['form_key']);
+            Mage::getSingleton('adminhtml/session')->addError("Unable to send to Sailthru. Please try again. POST: {$data}");
+        }
+        $this->_redirectReferer();
     }
 }

--- a/app/code/community/Sailthru/Email/controllers/ContentController.php
+++ b/app/code/community/Sailthru/Email/controllers/ContentController.php
@@ -1,0 +1,8 @@
+<?php
+class Sailthru_Email_ContentController extends Mage_Adminhtml_Controller_Action {
+
+    public function bulkAction() {
+        $data = $this->getRequest()->getPost();
+        Mage::log($data, null, "sailthru.log");
+    }
+}

--- a/app/code/community/Sailthru/Email/controllers/ContentController.php
+++ b/app/code/community/Sailthru/Email/controllers/ContentController.php
@@ -1,34 +1,54 @@
 <?php
 class Sailthru_Email_ContentController extends Mage_Adminhtml_Controller_Action {
 
-    public function bulkAction() {
-        $startTime = microtime(true);
-        $data = $this->getRequest()->getPost();
+    const MAX_ITEM_POST = 200;
 
+    /**
+     * <magento_uri>/content/bulk endpoint action
+     */
+    public function bulkAction() {
+        $data = $this->getRequest()->getPost();
+        Mage::log([
+            $this->getRequest()->getStoreCodeFromPath(),
+            Mage::getSingleton('adminhtml/config_data')->getStore(),
+            Mage::app()->getRequest()->getParam('store'),
+            Mage::app()->getStore()->debug(),
+        ], null, "sailthru.log");
+
+        Mage::log($data,null, "sailthru.log");
         if ($data and array_key_exists('product', $data) and array_key_exists('massaction_prepare_key', $data)
             and $pCount = count($data['product']) and $data['massaction_prepare_key'] == 'product') {
-
-            $savedProducts = 0;
-
-            /** @var int[] $productIds */
-            $productIds = $data['product'];
-            foreach ($productIds as $productId) {
-                /** @var Mage_Catalog_Model_Product $product */
-                $product = Mage::getModel('catalog/product')->load($productId);
-                $success = Mage::getModel('sailthruemail/observer_content')->syncProduct($product, true);
-                if ($success) ++$savedProducts;
-                usleep(0.25 * 1000000);
-            }
-
-            $endTime = microtime(true);
-            $time = $endTime - $startTime;
-            $message = "Succesfully sync'd $savedProducts / $pCount products to Sailthru";
-            Mage::getSingleton('adminhtml/session')->addNotice($message.".");
-            Mage::log($message . "in $time seconds", null, "sailthru.log");
+            $waitForResponse = $this->_processItems($data['product']);
         } else {
             unset($data['form_key']);
-            Mage::getSingleton('adminhtml/session')->addError("Unable to send to Sailthru. Please try again. POST: {$data}");
+            Mage::getSingleton('adminhtml/session')->addError("Request was malformed. Please try again. POST: {$data}");
         }
         $this->_redirectReferer();
     }
+
+    private function _processItems($productIds) {
+        $count = count($productIds);
+        if ($count > self::MAX_ITEM_POST) {
+            Mage::getSingleton('adminhtml/session')->addError("Unable to send to Sailthru - please select " . self::MAX_ITEM_POST . " items max. ($count selected)");
+            return;
+        }
+        $startTime = microtime(true);
+        $savedProducts = 0;
+
+        /** @var int[] $productIds */
+        foreach ($productIds as $productId) {
+            /** @var Mage_Catalog_Model_Product $product */
+            $product = Mage::getModel('catalog/product')->load($productId);
+            $success = Mage::getModel('sailthruemail/observer_content')->syncProduct($product, true);
+            if ($success) ++$savedProducts;
+            usleep(0.25 * 1000000);
+        }
+
+        $endTime = microtime(true);
+        $time = $endTime - $startTime;
+        $message = "Succesfully sync'd $savedProducts / $count products to Sailthru";
+        Mage::getSingleton('adminhtml/session')->addNotice($message.".");
+        Mage::log($message . "in $time seconds", null, "sailthru.log");
+    }
+
 }

--- a/app/code/community/Sailthru/Email/etc/config.xml
+++ b/app/code/community/Sailthru/Email/etc/config.xml
@@ -192,6 +192,14 @@
     </frontend>
     <adminhtml>
         <events>
+            <adminhtml_block_html_before>
+                <observers>
+                    <sailthru_add_action>
+                        <model>sailthruemail/observer_content</model>
+                        <method>addBlockMassAction</method>
+                    </sailthru_add_action>
+                </observers>
+            </adminhtml_block_html_before>
         </events>
     </adminhtml>
    <admin>

--- a/app/code/community/Sailthru/Email/etc/config.xml
+++ b/app/code/community/Sailthru/Email/etc/config.xml
@@ -195,7 +195,7 @@
             <adminhtml_block_html_before>
                 <observers>
                     <sailthru_add_action>
-                        <model>sailthruemail/observer_content</model>
+                        <model>sailthruemail/observer_adminhtml</model>
                         <method>addBlockMassAction</method>
                     </sailthru_add_action>
                 </observers>


### PR DESCRIPTION
This adds a Mass Action for the Admin Product Catalog page capable of sending many products to Sailthru at once. Can definitely take up to 50 products at once. 

\*also uses a better inventory getter that should return only int values, which Sailthru needs.