### PR TITLE
Add "Send to Sailthru" Product Grid Mass Action

### DIFF
--- a/app/code/community/Sailthru/Email/Helper/Data.php
+++ b/app/code/community/Sailthru/Email/Helper/Data.php
@@ -44,6 +44,7 @@ class Sailthru_Email_Helper_Data extends Mage_Core_Helper_Abstract
     const XML_PATH_TAGS_USE_CATEGORIES                      = 'sailthru_content/product_sync/use_categories';
     const XML_PATH_TAGS_USE_ATTRIBUTES                      = 'sailthru_content/product_sync/use_attributes';
     const XML_PATH_TAGS_ATTRIBUTE_CODES                     = 'sailthru_content/product_sync/attributes';
+    const XML_PATH_BETA_MASS_ACTION                         = 'sailthru_content/beta/mass_action';
 
     /**
      * Check to see if Sailthru plugin is enabled
@@ -204,6 +205,16 @@ class Sailthru_Email_Helper_Data extends Mage_Core_Helper_Abstract
     public function isProductSyncEnabled($store = null)
     {
         return boolval(Mage::getStoreConfig(self::XML_PATH_PRODUCT_SYNC, $store));
+    }
+
+    /**
+     * Check if beta product save mass action is enabled
+     * @param null $store
+     * @return bool
+     */
+    public function isProductMassActionEnabled($store = null)
+    {
+        return boolval(Mage::getStoreConfig(self::XML_PATH_BETA_MASS_ACTION));
     }
 
     /**

--- a/app/code/community/Sailthru/Email/Model/Client/Content.php
+++ b/app/code/community/Sailthru/Email/Model/Client/Content.php
@@ -115,7 +115,7 @@ class Sailthru_Email_Model_Client_Content extends Sailthru_Email_Model_Client
             )
         );
 
-        if ($isSimple) $data['inventory'] = $product->getStockItem()->getQty();
+        if ($isSimple) $data['inventory'] = $product->getStockItem()->getStockQty();
 
         // PRICE-FIXING CODE
         $data['price'] = Mage::helper('sailthruemail')->getPrice($product);

--- a/app/code/community/Sailthru/Email/Model/Observer/Adminhtml.php
+++ b/app/code/community/Sailthru/Email/Model/Observer/Adminhtml.php
@@ -23,7 +23,7 @@ class Sailthru_Email_Model_Observer_Adminhtml
 
             /** @var Mage_Adminhtml_Block_Widget_Grid_Massaction_Abstract $block */
             $block->addItem('sailthruemail_content_bulk', array(
-                'label' => 'Send to Sailthru Content Library',
+                'label' => '[BETA] Send to Sailthru',
                 'url' => $block->getUrl('sailthruemail/content/bulk'),
                 'additional' => array(
                     'store' => array(

--- a/app/code/community/Sailthru/Email/Model/Observer/Adminhtml.php
+++ b/app/code/community/Sailthru/Email/Model/Observer/Adminhtml.php
@@ -1,0 +1,34 @@
+<?php
+
+class Sailthru_Email_Model_Observer_Adminhtml
+{
+    /**
+     * Catch loading of Catalog Product Admin and insert a new mass action to send to Sailthru.
+     * @param Varien_Event_Observer $observer
+     */
+    public function addBlockMassAction(Varien_Event_Observer $observer) {
+        $block = $observer->getEvent()->getBlock();
+
+        // verify this is for a specific store, or a single-store Magento instance
+        $store = $block->getRequest()->getParam('store');
+        if (!$store and count(Mage::app()->getStores()) == 1) {
+            $store = 1;
+        }
+
+        // we only want to add this to the Product Catalog mass action block
+        if($store != null and get_class($block) =='Mage_Adminhtml_Block_Widget_Grid_Massaction'
+            && $block->getRequest()->getControllerName() == 'catalog_product') {
+
+            /** @var Mage_Adminhtml_Block_Widget_Grid_Massaction_Abstract $block */
+            $block->addItem('sailthruemail_content_bulk', array(
+                'label' => 'Send to Sailthru Content Library',
+                'url' => $block->getUrl('sailthruemail/content/bulk'),
+                'additional' => array(
+                    'store' => array(
+                        'name' => 'store',
+                        'type' => 'hidden',
+                        'value' => $store
+                ))));
+        }
+    }
+}

--- a/app/code/community/Sailthru/Email/Model/Observer/Adminhtml.php
+++ b/app/code/community/Sailthru/Email/Model/Observer/Adminhtml.php
@@ -15,9 +15,11 @@ class Sailthru_Email_Model_Observer_Adminhtml
             $store = 1;
         }
 
+        $featureEnabled = (Mage::helper('sailthruemail')->isEnabled() and Mage::helper('sailthruemail')->isProductMassActionEnabled());
+
         // we only want to add this to the Product Catalog mass action block
         if($store != null and get_class($block) =='Mage_Adminhtml_Block_Widget_Grid_Massaction'
-            && $block->getRequest()->getControllerName() == 'catalog_product') {
+            && $block->getRequest()->getControllerName() == 'catalog_product' and $featureEnabled) {
 
             /** @var Mage_Adminhtml_Block_Widget_Grid_Massaction_Abstract $block */
             $block->addItem('sailthruemail_content_bulk', array(

--- a/app/code/community/Sailthru/Email/controllers/ContentController.php
+++ b/app/code/community/Sailthru/Email/controllers/ContentController.php
@@ -24,7 +24,7 @@ class Sailthru_Email_ContentController extends Mage_Adminhtml_Controller_Action 
      * @param int $store
      */
     private function _processItems($productIds, $store) {
-        if (count($productIds) > self::MAX_ITEM_POST) {
+        if (($count = count($productIds)) > self::MAX_ITEM_POST) {
             Mage::getSingleton('adminhtml/session')->addError("Unable to send to Sailthru - please select " . self::MAX_ITEM_POST . " items max. ($count selected)");
             return;
         }

--- a/app/code/community/Sailthru/Email/controllers/ContentController.php
+++ b/app/code/community/Sailthru/Email/controllers/ContentController.php
@@ -1,0 +1,63 @@
+<?php
+class Sailthru_Email_ContentController extends Mage_Adminhtml_Controller_Action {
+
+    const MAX_ITEM_POST = 350;
+
+    /**
+     * <magento_uri>/content/bulk endpoint action
+     */
+    public function bulkAction() {
+        $data = $this->getRequest()->getPost();
+        if ($data and array_key_exists('product', $data) and
+            array_key_exists('massaction_prepare_key', $data) and $data['massaction_prepare_key'] == 'product' and
+            array_key_exists('store', $data) and intval($data['store']) > 0) {
+            $this->_processItems($data['product'], $data['store']);
+        } else {
+            Mage::getSingleton('adminhtml/session')->addError("Request to bulk update Sailthru was malformed. Please try again.");
+        }
+        $this->_redirectReferer();
+    }
+
+    /**
+     * Send products to Sailthru by ID number and a given store
+     * @param int[] $productIds
+     * @param int $store
+     */
+    private function _processItems($productIds, $store) {
+        if (count($productIds) > self::MAX_ITEM_POST) {
+            Mage::getSingleton('adminhtml/session')->addError("Unable to send to Sailthru - please select " . self::MAX_ITEM_POST . " items max. ($count selected)");
+            return;
+        }
+
+        /** @var Mage_Core_Model_App_Emulation $appEmulation */
+        $appEmulation = Mage::getSingleton('core/app_emulation');
+        $emulateData = $appEmulation->startEnvironmentEmulation($store);
+        $count = count($productIds);
+        $startTime = microtime(true);
+
+        $savedProducts = 0;
+        $erroredProducts = array();
+        /** @var int[] $productIds */
+        foreach ($productIds as $productId) {
+            /** @var Mage_Catalog_Model_Product $product */
+            $product = Mage::getModel('catalog/product')->load($productId);
+            try {
+                $success = Mage::getModel('sailthruemail/client_content')->saveProduct($product);
+                if ($success) $savedProducts++;
+            } catch (Sailthru_Client_Exception $e) {
+                Mage::getSingleton('adminhtml/session')
+                    ->addError("Error saving {$product->getName()} ({$product->getSku()})" .
+                        "<pre >({$e->getCode()}) {$e->getMessage()}</pre>"
+                    );
+            }
+            usleep(0.25 * 1000000);
+        }
+        $endTime = microtime(true);
+        $time = $endTime - $startTime;
+        $appEmulation->stopEnvironmentEmulation($emulateData);
+        $message = "Succesfully sync'd $savedProducts / $count products to Sailthru";
+        Mage::getSingleton('adminhtml/session')->addNotice($message.".");
+        Mage::log($message . "in $time seconds", null, "sailthru.log");
+    }
+
+}

--- a/app/code/community/Sailthru/Email/etc/config.xml
+++ b/app/code/community/Sailthru/Email/etc/config.xml
@@ -14,7 +14,7 @@
     </modules>
     <global>
         <models>
-           <sailthruemail>
+            <sailthruemail>
                 <class>Sailthru_Email_Model</class>
             </sailthruemail>
             <core>
@@ -165,14 +165,14 @@
                     </sailthru_newsletter_subscriber_delete_after>
                 </observers>
             </newsletter_subscriber_delete_after>
-     </events>
+        </events>
         <routers>
-        <sailthruemail>
-            <use>standard</use>
-            <args>
-                <module>Sailthru_Email</module>
-                <frontName>email</frontName>
-            </args>
+            <sailthruemail>
+                <use>standard</use>
+                <args>
+                    <module>Sailthru_Email</module>
+                    <frontName>email</frontName>
+                </args>
             </sailthruemail>
             <checkout>
                 <args>
@@ -192,9 +192,17 @@
     </frontend>
     <adminhtml>
         <events>
+            <adminhtml_block_html_before>
+                <observers>
+                    <sailthru_add_action>
+                        <model>sailthruemail/observer_adminhtml</model>
+                        <method>addBlockMassAction</method>
+                    </sailthru_add_action>
+                </observers>
+            </adminhtml_block_html_before>
         </events>
     </adminhtml>
-   <admin>
+    <admin>
         <routers>
             <sailthruemail>
                 <use>admin</use>
@@ -210,7 +218,7 @@
             <api>
                 <uri><![CDATA[https://api.sailthru.com]]></uri>
             </api>
-       </sailthru>
+        </sailthru>
         <sailthru_transactional>
             <email>
                 <customer_error_enabled>1</customer_error_enabled>

--- a/app/code/community/Sailthru/Email/etc/system.xml
+++ b/app/code/community/Sailthru/Email/etc/system.xml
@@ -557,6 +557,31 @@
                         </attributes>
                     </fields>
                 </product_sync>
+                <beta>
+                    <label>Beta Features</label>
+                    <frontend_type>text</frontend_type>
+                    <sort_order>2</sort_order>
+                    <show_in_default>1</show_in_default>
+                    <show_in_website>1</show_in_website>
+                    <show_in_store>1</show_in_store>
+                    <fields>
+                        <mass_action translate="label comment">
+                            <label>Enable Product Mass Action</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>Sailthru_Email_Model_Config_Source_Validatedyesno</source_model>
+                            <sort_order>1</sort_order>
+                            <comment>
+                                <![CDATA[
+                                Displays a new multi-item action in the admin catalog screen, allowing you to send many products to Sailthru at once. Can take multiple minutes, and may run into memory errors with too many items.
+                                This action is only available in single-store mode or store-specific scope.
+                            ]]>
+                            </comment>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </mass_action>
+                    </fields>
+                </beta>
             </groups>
         </sailthru_content>
     </sections>


### PR DESCRIPTION
This adds a new *BETA* feature to the integration, allowing sync'ing of up to 350 products at a time to Sailthru via Mass Action. The mass action will be visible the admin product catalog view when in single-store mode or when at store scope. 

![image](https://user-images.githubusercontent.com/5976818/29886503-4581d960-8d88-11e7-9a0b-abfcb8cac6a6.png)
