### PR TITLE
Improve Content API Sync & Mass Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ For questions or troubleshooting, please visit [Sailthru Support][5] or submit a
 
 ## Installation 
 * *After installation, you may need to login, clear cache, and then re-login.*
+* *This repo defaults to the **develop** branch. If looking for latest LTS release, please use **master**.*
 
 ### Manual Installation
 

--- a/app/code/community/Sailthru/Email/Helper/Data.php
+++ b/app/code/community/Sailthru/Email/Helper/Data.php
@@ -428,4 +428,8 @@ class Sailthru_Email_Helper_Data extends Mage_Core_Helper_Abstract
         return $vars;
     }
 
+    public final function isContentNotExistError(Sailthru_Client_Exception $e) {
+        return ($e->getCode() == 99 and strpos($e->getMessage(), "Content not found") !== false);
+    }
+
 }

--- a/app/code/community/Sailthru/Email/Model/Client/Content.php
+++ b/app/code/community/Sailthru/Email/Model/Client/Content.php
@@ -115,7 +115,15 @@ class Sailthru_Email_Model_Client_Content extends Sailthru_Email_Model_Client
             )
         );
 
-        if ($isSimple) $data['inventory'] = $product->getStockItem()->getStockQty();
+        if ($isSimple) {
+            if ($product->getStockItem()->getQty() || $product->getQty()) {
+                $inv = $product->getStockItem()->getQty() ?: intval($product->getQty());
+                if ($inv < 0) {
+                    $inv = 0;
+                }
+                $data['inventory'] = $inv;
+            }
+        }
 
         // PRICE-FIXING CODE
         $data['price'] = Mage::helper('sailthruemail')->getPrice($product);

--- a/app/code/community/Sailthru/Email/controllers/ContentController.php
+++ b/app/code/community/Sailthru/Email/controllers/ContentController.php
@@ -61,13 +61,14 @@ class Sailthru_Email_ContentController extends Mage_Adminhtml_Controller_Action
             /** @var Mage_Catalog_Model_Product $product */
             foreach ($collection->getItems() as $product) {
                 try {
-                    if ($product->getStatus() == Mage_Catalog_Model_Product_Status::STATUS_ENABLED) {
+                    $status = $product->getStatus();
+                    if ($status == Mage_Catalog_Model_Product_Status::STATUS_ENABLED) {
                         $success = Mage::getModel('sailthruemail/client_content')->saveProduct($product);
                         if ($success) {
                             $syncedProducts++;
                         }
 
-                    } elseif ($product->getStatus() == Mage_Catalog_Model_Product_Status::STATUS_DISABLED) {
+                    } elseif ($status == Mage_Catalog_Model_Product_Status::STATUS_DISABLED) {
                         try {
                             $success = Mage::getModel('sailthruemail/client_content')->deleteProduct($product);
                             if ($success) {


### PR DESCRIPTION
* If a product is disabled, the plugin attempts to delete it from Sailthru Content Library. Previously, if the product hadn't been in the Content Library, a UI error would be raised saying "Content could not be found". This issue is resolved.
* When getting the product query for the mass action, stock model is not included. This improved query adds in inventory without the stock model.