### PR TITLE
2.0.1 - Fix HID Cart

### DIFF
--- a/app/code/community/Sailthru/Email/Helper/Data.php
+++ b/app/code/community/Sailthru/Email/Helper/Data.php
@@ -34,7 +34,7 @@ class Sailthru_Email_Helper_Data extends Mage_Core_Helper_Abstract
     const XML_PATH_ABANDONED_CART_DELAY                     = 'sailthru_transactional/abandoned_cart/delay';
     const XML_PATH_ANONYMOUS_CART_ENABLED                   = 'sailthru_transactional/anonymous_cart/enabled';
     const XML_PATH_ANONYMOUS_CART_TEMPLATE                  = 'sailthru_transactional/anonymous_cart/template';
-    const XML_PATH_ANONYMOUS_CART_DELAY                     = 'sailthru_transactional/anonymous_cart/delay';
+    const XML_PATH_ANONYMOUS_CART_DELAY                     = 'sailthru_transactional/anonymous_cart/reminder_time';
 
     // Content
     const XML_PATH_PRODUCT_SYNC                             = 'sailthru_content/product_sync/enabled';

--- a/app/code/community/Sailthru/Email/etc/config.xml
+++ b/app/code/community/Sailthru/Email/etc/config.xml
@@ -9,7 +9,7 @@
 <config>
     <modules>
         <Sailthru_Email>
-            <version>2.0.0</version>
+            <version>2.0.1</version>
         </Sailthru_Email>
     </modules>
     <global>


### PR DESCRIPTION
This fixes a bug with the HID-based abandoned cart functionality, which caused the HID-based cart, when enabled, to send immediately rather than by the time set in the admin.