### PR TITLE
IN-1016 Abandoned Cart Patch (Master)

### DIFF
--- a/app/code/community/Sailthru/Email/Helper/Purchase.php
+++ b/app/code/community/Sailthru/Email/Helper/Purchase.php
@@ -125,5 +125,22 @@ class Sailthru_Email_Helper_Purchase extends Mage_Core_Helper_Abstract
         return $vars;
     }
 
+    public function getItemVars(Mage_Sales_Model_Order_Item $item) {
+        return $this->getVars($this->getAttributes($item));
+    }
+
+    private function getAttributes(Mage_Sales_Model_Order_Item $item) {
+        $ATTRIBUTES_KEY = 'attributes_info';
+        $product = $item->getProduct();
+        $options = $product->getTypeInstance(true)->getOrderOptions($product);
+        if (array_key_exists($ATTRIBUTES_KEY, $options)) {
+            return $options[$ATTRIBUTES_KEY];
+        }
+        if (array_key_exists($ATTRIBUTES_KEY, $item->getProductOptions())) {
+            return $item->getProductOptions()[$ATTRIBUTES_KEY];
+        }
+        return null;
+    }
+
 }
 

--- a/app/code/community/Sailthru/Email/Helper/Purchase.php
+++ b/app/code/community/Sailthru/Email/Helper/Purchase.php
@@ -125,18 +125,28 @@ class Sailthru_Email_Helper_Purchase extends Mage_Core_Helper_Abstract
         return $vars;
     }
 
-    public function getItemVars(Mage_Sales_Model_Order_Item $item) {
+    /**
+     * @param Mage_Sales_Model_Order_Item|Mage_Sales_Model_Quote_Item $item
+     * @return array
+     */
+    public function getItemVars($item) {
         return $this->getVars($this->getAttributes($item));
     }
 
-    private function getAttributes(Mage_Sales_Model_Order_Item $item) {
+    /**
+     * Resolve attributes
+     * @param Mage_Sales_Model_Order_Item|Mage_Sales_Model_Quote_Item $item
+     *
+     * @return null
+     */
+    private function getAttributes($item) {
         $ATTRIBUTES_KEY = 'attributes_info';
         $product = $item->getProduct();
         $options = $product->getTypeInstance(true)->getOrderOptions($product);
         if (array_key_exists($ATTRIBUTES_KEY, $options)) {
             return $options[$ATTRIBUTES_KEY];
         }
-        if (array_key_exists($ATTRIBUTES_KEY, $item->getProductOptions())) {
+        if (array_key_exists($ATTRIBUTES_KEY, $item->getProductOptions() ?: [])) {
             return $item->getProductOptions()[$ATTRIBUTES_KEY];
         }
         return null;

--- a/app/code/community/Sailthru/Email/Model/Client.php
+++ b/app/code/community/Sailthru/Email/Model/Client.php
@@ -115,7 +115,7 @@ class Sailthru_Email_Model_Client extends Sailthru_Client
 
     public function logException(Exception $e)
     {
-        Mage::log($e);
+        Mage::logException($e);
         $this->log("Error: " . get_class($e) . ": {$e->getMessage()}. See exception.log for more details", Zend_Log::ERR);
     }
 

--- a/app/code/community/Sailthru/Email/Model/Client.php
+++ b/app/code/community/Sailthru/Email/Model/Client.php
@@ -76,13 +76,11 @@ class Sailthru_Email_Model_Client extends Sailthru_Client
         try {
             $response = parent::httpRequest($action, $data, $method, $options);
         } catch (Sailthru_Client_Exception $e) {
-            $this->log(
-                array(
+            $this->log(array(
                 'action'        => $logAction,
                 'error'         => $e->getCode(),
                 'error message' => $e->getMessage(),
-                )
-            );
+                ), Zend_Log::ERR);
             throw $e;
         }
 
@@ -108,11 +106,17 @@ class Sailthru_Email_Model_Client extends Sailthru_Client
         return isset($cookie_vals['sailthru_bid']) ? $cookie_vals['sailthru_bid'] : null;
     }
 
-    public function log($data) 
+    public function log($data, $level=null)
     {
         if (Mage::helper('sailthruemail')->isLoggingEnabled($this->_storeId)) {
-            Mage::log($data, null, 'sailthru.log');
+            Mage::log($data, $level, 'sailthru.log');
         }
+    }
+
+    public function logException(Exception $e)
+    {
+        Mage::log($e);
+        $this->log("Error: " . get_class($e) . ": {$e->getMessage()}. See exception.log for more details", Zend_Log::ERR);
     }
 
     // Magento-friendly cookie-setter. Kept for backwards-compatibility with old plugin. TODO: refactor

--- a/app/code/community/Sailthru/Email/Model/Observer/Purchase.php
+++ b/app/code/community/Sailthru/Email/Model/Observer/Purchase.php
@@ -21,7 +21,7 @@ class Sailthru_Email_Model_Observer_Purchase extends Sailthru_Email_Model_Observ
         $num_qty = $quote->getItemsQty();
         if($quote->getItemsCount() == 0 && $this->isCartEnabled()) {
             try{
-                 $response = Mage::getModel('sailthruemail/client_purchase')->sendCart($quote, $this->_email, 'EmptiedCart');
+                 $response = Mage::getModel('sailthruemail/client_purchase')->sendCart($quote, 'EmptiedCart');
             } catch (Exception $e) {
                 Mage::logException($e);
             }
@@ -32,7 +32,7 @@ class Sailthru_Email_Model_Observer_Purchase extends Sailthru_Email_Model_Observ
     {
         if($this->isCartEnabled()) {
             try{
-                $response = Mage::getModel('sailthruemail/client_purchase')->sendCart($observer->getQuoteItem()->getQuote(), $this->_email, 'addItemToCart');
+                $response = Mage::getModel('sailthruemail/client_purchase')->sendCart($observer->getQuoteItem()->getQuote(), 'addItemToCart');
             } catch (Exception $e) {
                 Mage::logException($e);
             }
@@ -44,7 +44,7 @@ class Sailthru_Email_Model_Observer_Purchase extends Sailthru_Email_Model_Observ
         if($this->isCartEnabled()) {
             try{
                 if ($hasChanges = $observer->getCart()->hasDataChanges()) {
-                    $response = Mage::getModel('sailthruemail/client_purchase')->sendCart($observer->getCart()->getQuote(), $this->_email, 'updateItemInCart');
+                    $response = Mage::getModel('sailthruemail/client_purchase')->sendCart($observer->getCart()->getQuote(), 'updateItemInCart');
                 }
             } catch (Exception $e) {
                 Mage::logException($e);
@@ -56,7 +56,7 @@ class Sailthru_Email_Model_Observer_Purchase extends Sailthru_Email_Model_Observ
     {
         if($this->isCartEnabled()) {
             try{
-                 Mage::getModel('sailthruemail/client_purchase')->sendCart($observer->getQuoteItem()->getQuote(), $this->_email, 'removeItemFromCart');
+                 Mage::getModel('sailthruemail/client_purchase')->sendCart($observer->getQuoteItem()->getQuote(), 'removeItemFromCart');
             } catch (Exception $e) {
                 Mage::logException($e);
             }


### PR DESCRIPTION
This PR applies the #105 Abandoned Cart Patch to Master.

* Addresses a bug for abandoned carts when a guest user has an invalid HID cookie
* Makes all Sailthru API errors record as errors in `sailthru.log`, and creates a new utility to better record exceptions across `sailthru.log` and `exception.log`
* Addresses PHP notice `Undefined Index` for attributes_info in Purchase Client
* Addresses PHP notice  `Undefined Property` for $_email in Purchase Observer